### PR TITLE
Fix relay Bug when node is out of eth

### DIFF
--- a/multiple-erc20-to-erc20/oracle/src/sender.js
+++ b/multiple-erc20-to-erc20/oracle/src/sender.js
@@ -141,7 +141,7 @@ async function main ({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
           `Tx Failed for event Tx ${job.transactionReference}.`,
           e.message
         )
-
+        
         var lowerCaseErrorString = e.message.toLowerCase()
 
         if (!lowerCaseErrorString.includes('transaction with the same hash was already imported')) {
@@ -186,7 +186,7 @@ async function main ({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
         'Insufficient funds. Stop sending transactions until the account has the minimum balance'
       )
       channel.close()
-      waitForFunds(web3Instance, VALIDATOR_ADDRESS, minimumBalance, resume, logger)
+      waitForFunds(web3Instance, VALIDATOR_ADDRESS, web3Instance.utils.toBN(minimumBalance), resume, logger)
     }
   } catch (e) {
     logger.error(e)

--- a/multiple-erc20-to-erc20/oracle/src/sender.js
+++ b/multiple-erc20-to-erc20/oracle/src/sender.js
@@ -141,12 +141,15 @@ async function main ({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
           `Tx Failed for event Tx ${job.transactionReference}.`,
           e.message
         )
-        if (!e.message.includes('Transaction with the same hash was already imported')) {
+
+        var lowerCaseErrorString = e.message.toLowerCase()
+
+        if (!lowerCaseErrorString.includes('transaction with the same hash was already imported')) {
           logger.debug(`adding event Tx ${job.transactionReference} to failedTx`)
           failedTx.push(job)
         }
 
-        if (e.message.includes('Insufficient funds')) {
+        if (lowerCaseErrorString.includes('insufficient funds')) {
           insufficientFunds = true
           const currentBalance = await web3Instance.eth.getBalance(VALIDATOR_ADDRESS)
           minimumBalance = gasLimit.multipliedBy(gasPrice)
@@ -154,9 +157,9 @@ async function main ({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
             `Insufficient funds: ${currentBalance}. Stop processing messages until the balance is at least ${minimumBalance}.`
           )
         } else if (
-          e.message.includes('Transaction nonce is too low') ||
-          e.message.includes('transaction with same nonce in the queue') ||
-          e.message.includes('nonce too low')
+          lowerCaseErrorString.includes('transaction nonce is too low') ||
+          lowerCaseErrorString.includes('transaction with same nonce in the queue') ||
+          lowerCaseErrorString.includes('nonce too low')
         ) {
           logger.debug('read nonce with forceUpdate=true')
           nonce = await readNonce(true)

--- a/multiple-erc20-to-erc20/oracle/src/utils/utils.js
+++ b/multiple-erc20-to-erc20/oracle/src/utils/utils.js
@@ -46,7 +46,9 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
     },
     {
       forever: true,
-      factor: 1
+      factor: 1,
+      minTimeout: 60 * 1000,
+      maxTimeout: 30 * 60 * 1000
     }
   )
 }

--- a/multiple-erc20-to-erc20/oracle/src/utils/utils.js
+++ b/multiple-erc20-to-erc20/oracle/src/utils/utils.js
@@ -30,7 +30,7 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
     async retry => {
       logger.debug('Getting balance of validator account')
       const newBalance = web3.utils.toBN(await web3.eth.getBalance(address))
-      if (newBalance >= minimumBalance) {
+      if (newBalance.gte(minimumBalance)) {
         logger.debug(
           { balance: newBalance, minimumBalance },
           'Validator has minimum necessary balance'

--- a/multiple-erc20-to-erc20/oracle/src/utils/utils.js
+++ b/multiple-erc20-to-erc20/oracle/src/utils/utils.js
@@ -49,7 +49,7 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
       forever: true,
       factor: 1.5,
       minTimeout: 60 * 1000, //min time = 1min
-      maxTimeout: 30 * 60 * 1000 //max time = 30min
+      maxTimeout: 10 * 60 * 1000 //max time = 10min
     }
   )
 }

--- a/multiple-erc20-to-erc20/oracle/src/utils/utils.js
+++ b/multiple-erc20-to-erc20/oracle/src/utils/utils.js
@@ -45,10 +45,11 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
       }
     },
     {
+      // scale the retry time depending on amount of failed attempts Math.min(random * minTimeout * Math.pow(factor, attempt), maxTimeout)
       forever: true,
-      factor: 1,
-      minTimeout: 60 * 1000,
-      maxTimeout: 30 * 60 * 1000
+      factor: 1.5,
+      minTimeout: 60 * 1000, //min time = 1min
+      maxTimeout: 30 * 60 * 1000 //max time = 30min
     }
   )
 }

--- a/multiple-erc20-to-erc20/oracle/src/utils/utils.js
+++ b/multiple-erc20-to-erc20/oracle/src/utils/utils.js
@@ -30,14 +30,14 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
     async retry => {
       logger.debug('Getting balance of validator account')
       const newBalance = web3.utils.toBN(await web3.eth.getBalance(address))
-      if (newBalance.gte(minimumBalance)) {
+      if (newBalance >= minimumBalance) {
         logger.debug(
           { balance: newBalance, minimumBalance },
           'Validator has minimum necessary balance'
         )
         cb(newBalance)
       } else {
-        logger.debug(
+        logger.warn(
           { balance: newBalance, minimumBalance },
           'Balance of validator is still less than the minimum'
         )

--- a/native-to-erc20/oracle/src/sender.js
+++ b/native-to-erc20/oracle/src/sender.js
@@ -186,7 +186,7 @@ async function main ({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
         'Insufficient funds. Stop sending transactions until the account has the minimum balance'
       )
       channel.close()
-      waitForFunds(web3Instance, VALIDATOR_ADDRESS, minimumBalance, resume, logger)
+      waitForFunds(web3Instance, VALIDATOR_ADDRESS, web3Instance.utils.toBN(minimumBalance), resume, logger)
     }
   } catch (e) {
     logger.error(e)

--- a/native-to-erc20/oracle/src/sender.js
+++ b/native-to-erc20/oracle/src/sender.js
@@ -141,12 +141,15 @@ async function main ({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
           `Tx Failed for event Tx ${job.transactionReference}.`,
           e.message
         )
-        if (!e.message.includes('Transaction with the same hash was already imported')) {
+
+        var lowerCaseErrorString = e.message.toLowerCase()
+
+        if (!lowerCaseErrorString.includes('transaction with the same hash was already imported')) {
           logger.debug(`adding event Tx ${job.transactionReference} to failedTx`)
           failedTx.push(job)
         }
 
-        if (e.message.includes('Insufficient funds')) {
+        if (lowerCaseErrorString.includes('insufficient funds')) {
           insufficientFunds = true
           const currentBalance = await web3Instance.eth.getBalance(VALIDATOR_ADDRESS)
           minimumBalance = gasLimit.multipliedBy(gasPrice)
@@ -154,9 +157,9 @@ async function main ({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
             `Insufficient funds: ${currentBalance}. Stop processing messages until the balance is at least ${minimumBalance}.`
           )
         } else if (
-          e.message.includes('Transaction nonce is too low') ||
-          e.message.includes('transaction with same nonce in the queue') ||
-          e.message.includes('nonce too low')
+          lowerCaseErrorString.includes('transaction nonce is too low') ||
+          lowerCaseErrorString.includes('transaction with same nonce in the queue') ||
+          lowerCaseErrorString.includes('nonce too low')
         ) {
           logger.debug('read nonce with forceUpdate=true')
           nonce = await readNonce(true)

--- a/native-to-erc20/oracle/src/utils/utils.js
+++ b/native-to-erc20/oracle/src/utils/utils.js
@@ -54,7 +54,9 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
     },
     {
       forever: true,
-      factor: 1
+      factor: 1,
+      minTimeout: 60 * 1000,
+      maxTimeout: 30 * 60 * 1000
     }
   )
 }

--- a/native-to-erc20/oracle/src/utils/utils.js
+++ b/native-to-erc20/oracle/src/utils/utils.js
@@ -38,7 +38,7 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
     async retry => {
       logger.debug('Getting balance of validator account')
       const newBalance = web3.utils.toBN(await web3.eth.getBalance(address))
-      if (newBalance >= minimumBalance) {
+      if (newBalance.gte(minimumBalance)) {
         logger.debug(
           { balance: newBalance, minimumBalance },
           'Validator has minimum necessary balance'

--- a/native-to-erc20/oracle/src/utils/utils.js
+++ b/native-to-erc20/oracle/src/utils/utils.js
@@ -53,10 +53,11 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
       }
     },
     {
+      // scale the retry time depending on amount of failed attempts Math.min(random * minTimeout * Math.pow(factor, attempt), maxTimeout)
       forever: true,
-      factor: 1,
-      minTimeout: 60 * 1000,
-      maxTimeout: 30 * 60 * 1000
+      factor: 1.5,
+      minTimeout: 60 * 1000, //min time = 1min
+      maxTimeout: 30 * 60 * 1000 //max time = 30min
     }
   )
 }

--- a/native-to-erc20/oracle/src/utils/utils.js
+++ b/native-to-erc20/oracle/src/utils/utils.js
@@ -57,7 +57,7 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
       forever: true,
       factor: 1.5,
       minTimeout: 60 * 1000, //min time = 1min
-      maxTimeout: 30 * 60 * 1000 //max time = 30min
+      maxTimeout: 10 * 60 * 1000 //max time = 10min
     }
   )
 }

--- a/native-to-erc20/oracle/src/utils/utils.js
+++ b/native-to-erc20/oracle/src/utils/utils.js
@@ -38,14 +38,14 @@ async function waitForFunds (web3, address, minimumBalance, cb, logger) {
     async retry => {
       logger.debug('Getting balance of validator account')
       const newBalance = web3.utils.toBN(await web3.eth.getBalance(address))
-      if (newBalance.gte(minimumBalance)) {
+      if (newBalance >= minimumBalance) {
         logger.debug(
           { balance: newBalance, minimumBalance },
           'Validator has minimum necessary balance'
         )
         cb(newBalance)
       } else {
-        logger.debug(
+        logger.warn(
           { balance: newBalance, minimumBalance },
           'Balance of validator is still less than the minimum'
         )


### PR DESCRIPTION
Fixes the error where the node would constantly try and relay the transaction when the nodes eth is too low to pay transaction fees this was due to a case mismatch on string comparisons. 

• do a comparison on lower case string only
• Increase retry time on checking for balance top up