### PR TITLE
Handling errors of the second gas oracle

### DIFF
--- a/native-to-erc20/oracle/src/services/gasPrice.js
+++ b/native-to-erc20/oracle/src/services/gasPrice.js
@@ -30,16 +30,23 @@ async function fetchGasPriceFromOracle (oracleUrl, speedType, factor) {
 }
 
 async function fetchGasPrice ({ oracleFn, secondaryOracleFn }) {
-  let gasPrice = null
   try {
-    gasPrice = await oracleFn()
-    logger.debug({ gasPrice }, 'Gas price updated using the oracle')
+    const gasPrice = await oracleFn()
+    logger.debug({ gasPrice }, 'Gas price updated using the first oracle')
+    return gasPrice
   } catch (e) {
     logger.error(`Primary Gas Price API is not available. ${e.message}`)
-    logger.info('Using the secondary Gas Price API')
-    gasPrice = await secondaryOracleFn()
   }
-  return gasPrice
+
+  try {
+    logger.info('Using the secondary Gas Price API')
+    const gasPrice = await secondaryOracleFn()
+    logger.debug({ gasPrice }, 'Gas price updated using the first oracle')
+    return gasPrice
+  } catch (e) {
+    logger.error(`Secondary Gas Price API is not available. ${e.message}`)
+  }
+  return null
 }
 
 let fetchGasPriceInterval = null

--- a/native-to-erc20/oracle/test/gasPrice.test.js
+++ b/native-to-erc20/oracle/test/gasPrice.test.js
@@ -15,22 +15,40 @@ describe('gasPrice', () => {
     it('should fetch the gas price from the oracle', async () => {
       // given
       const oracleFnMock = () => Promise.resolve('1')
+      const secondaryOracleFnMock = () => Promise.resolve('2')
 
       // when
       const gasPrice = await fetchGasPrice({
-        oracleFn: oracleFnMock
+        oracleFn: oracleFnMock,
+        secondaryOracleFn: secondaryOracleFnMock
       })
 
       // then
       expect(gasPrice).to.equal('1')
     })
-    it('should return null if the oracle fail', async () => {
+    it('should use secondary if the first oracle fail', async () => {
       // given
       const oracleFnMock = () => Promise.reject(new Error('oracle failed'))
+      const secondaryOracleFnMock = () => Promise.resolve('2')
 
       // when
       const gasPrice = await fetchGasPrice({
-        oracleFn: oracleFnMock
+        oracleFn: oracleFnMock,
+        secondaryOracleFn: secondaryOracleFnMock
+      })
+
+      // then
+      expect(gasPrice).to.equal('2')
+    })
+    it('should return null if both the oracle fail', async () => {
+      // given
+      const oracleFnMock = () => Promise.reject(new Error('oracle failed'))
+      const secondaryOracleFnMock = () => Promise.reject(new Error('oracle failed'))
+
+      // when
+      const gasPrice = await fetchGasPrice({
+        oracleFn: oracleFnMock,
+        secondaryOracleFn: secondaryOracleFnMock
       })
 
       // then


### PR DESCRIPTION
- Raised errors of the secondary oracle wasn't handled. This PR catches this errors in the same way as the first oracle does so