### PR TITLE
Feat/adding setValidatorContract method

### DIFF
--- a/native-to-erc20/contracts/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/native-to-erc20/contracts/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -54,6 +54,10 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
         erc677token().claimTokens(_token, _to);
     }
 
+    function setValidatorContract(address _validatorContract) external onlyIfOwnerOfProxy {
+        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
+    }
+
     function executeSignatures(uint8[] vs, bytes32[] rs, bytes32[] ss, bytes message) external {
         require(Message.isMessageValid(message));
         Message.hasEnoughValidSignaturesForeignBridgeValidator(message, vs, rs, ss, validatorContract());

--- a/native-to-erc20/contracts/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/native-to-erc20/contracts/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -60,6 +60,10 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge {
         return bytes4(keccak256(abi.encodePacked("native-to-erc-core")));
     }
 
+    function setValidatorContract(address _validatorContract) external onlyIfOwnerOfProxy {
+        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
+    }
+
     function onExecuteAffirmation(address _recipient, uint256 _value) internal returns(bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_value));
         if (!_recipient.send(_value)) {

--- a/native-to-erc20/contracts/test/native_to_erc/foreign_bridge_test.js
+++ b/native-to-erc20/contracts/test/native_to_erc/foreign_bridge_test.js
@@ -639,6 +639,20 @@ contract('ForeignBridge_Native_to_ERC20', async (accounts) => {
       await storageProxy.upgradeToAndCall('1', foreignBridge.address, data).should.be.fulfilled;
       await storageProxy.transferProxyOwnership(owner).should.be.fulfilled
     })
+
+    it('only proxy owner can call setValidatorContract', async () => {
+      const token = await POA20.new("POA ERC20 Foundation", "POA20", 18);
+      let storageProxy = await EternalStorageProxy.new().should.be.fulfilled;
+      const foreignContract =  await ForeignBridge.new();
+      const data = foreignContract.initialize.request(
+        validatorContract.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, erc677tokenPreMinted).params[0].data
+      await storageProxy.upgradeToAndCall('1', foreignContract.address, data).should.be.fulfilled;
+      await storageProxy.transferProxyOwnership(owner).should.be.fulfilled
+      
+      const foreignBridge = await ForeignBridge.at(storageProxy.address);
+      await foreignBridge.setValidatorContract(validatorContract.address).should.be.fulfilled
+      await foreignBridge.setValidatorContract(validatorContract.address, { from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
+    })
   })
 
   describe('#claimTokens', async () => {

--- a/native-to-erc20/contracts/test/native_to_erc/home_bridge_test.js
+++ b/native-to-erc20/contracts/test/native_to_erc/home_bridge_test.js
@@ -79,6 +79,16 @@ contract('HomeBridge_Native_to_ERC20', async (accounts) => {
       await storageProxy.upgradeToAndCall('1', homeContract.address, data).should.be.fulfilled;
       await storageProxy.transferProxyOwnership(owner).should.be.fulfilled
     })
+
+    it('only proxy owner can call setValidatorContract', async () => {
+      let storageProxy = await EternalStorageProxy.new().should.be.fulfilled;
+      let data = homeContract.initialize.request(validatorContract.address, "3", "2", "1", gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner).params[0].data
+      await storageProxy.upgradeToAndCall('1', homeContract.address, data).should.be.fulfilled;
+      const homeBridge = await HomeBridge.at(storageProxy.address);
+
+      await homeBridge.setValidatorContract(validatorContract.address).should.be.fulfilled
+      await homeBridge.setValidatorContract(validatorContract.address, { from: accounts[1]}).should.be.rejectedWith(ERROR_MSG);
+    })
   })
 
   describe('#fallback', async () => {
@@ -542,120 +552,6 @@ contract('HomeBridge_Native_to_ERC20', async (accounts) => {
     })
   })
 
- /*  describe('#submitSignatureOfMessageWithUnknownLength', async () => {
-    let validatorContractWith2Signatures,authoritiesTwoAccs,ownerOfValidators,tokenPOA20,homeBridgeWithTwoSigs
-    beforeEach(async () => {
-      validatorContractWith2Signatures = await BridgeValidators.new()
-      authoritiesTwoAccs = [accounts[1], accounts[2], accounts[3]];
-      ownerOfValidators = accounts[0]
-      await validatorContractWith2Signatures.initialize(2, authoritiesTwoAccs, ownerOfValidators)
-      homeBridgeWithTwoSigs = await HomeBridge.new();
-      await homeBridgeWithTwoSigs.initialize(validatorContractWith2Signatures.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner);
-    })
-    it('allows a validator to submit a signature', async () => {
-      var newSet = [accounts[1], accounts[2]];
-      var transactionHash = "0x1045bfe274b88120a6b1e5d01b5ec00ab5d01098346e90e7c7a3c9b8f0181c80";
-      var blockNumber = web3.toBigNumber(217455)
-      var message = createNewSetMessage(newSet, transactionHash, blockNumber, homeBridgeWithTwoSigs.address);
-      var signature = await sign(authoritiesTwoAccs[0], message)
-      const {logs} = await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature, message, {from: authorities[0]}).should.be.fulfilled;
-      logs[0].event.should.be.equal('SignedForUserRequest')
-      const msgHashFromLog = logs[0].args.messageHash
-      const signatureFromContract = await homeBridgeWithTwoSigs.signature(msgHashFromLog, 0);
-      const messageFromContract = await homeBridgeWithTwoSigs.message(msgHashFromLog);
-      signature.should.be.equal(signatureFromContract);
-      message.should.be.equal(messageFromContract);
-      const hashMsg = Web3Utils.soliditySha3(message);
-      '1'.should.be.bignumber.equal(await homeBridgeWithTwoSigs.numMessagesSigned(hashMsg))
-      const hashSenderMsg = Web3Utils.soliditySha3(authorities[0], hashMsg)
-      true.should.be.equal(await homeBridgeWithTwoSigs.messagesSigned(hashSenderMsg));
-    })
-    it('when enough requiredSignatures are collected, CollectedSignatures event is emitted', async () => {
-      var newSet = [accounts[1], accounts[2]];
-      var homeGasPrice = web3.toBigNumber(0);
-      var transactionHash = "0x1045bfe274b88120a6b1e5d01b5ec00ab5d01098346e90e7c7a3c9b8f0181c80";
-      var blockNumber = web3.toBigNumber(217455)
-      var message = createNewSetMessage(newSet, transactionHash, blockNumber, homeBridgeWithTwoSigs.address);
-      const hashMsg = Web3Utils.soliditySha3(message);
-      var signature = await sign(authoritiesTwoAccs[0], message)
-      var signature2 = await sign(authoritiesTwoAccs[1], message)
-      '2'.should.be.bignumber.equal(await validatorContractWith2Signatures.requiredSignatures());
-      await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature, message, {from: authoritiesTwoAccs[0]}).should.be.fulfilled;
-      await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature, message, {from: authoritiesTwoAccs[0]}).should.be.rejectedWith(ERROR_MSG);
-      await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature, message, {from: authoritiesTwoAccs[1]}).should.be.rejectedWith(ERROR_MSG);
-      const {logs} = await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature2, message, {from: authoritiesTwoAccs[1]}).should.be.fulfilled;
-      logs.length.should.be.equal(2)
-      logs[1].event.should.be.equal('CollectedSignatures')
-      logs[1].args.authorityResponsibleForRelay.should.be.equal(authoritiesTwoAccs[1])
-      const markedAsProcessed = new web3.BigNumber(2).pow(255).add(2);
-      markedAsProcessed.should.be.bignumber.equal(await homeBridgeWithTwoSigs.numMessagesSigned(hashMsg))
-    })
-    it('works with 5 validators and 3 required signatures', async () => {
-      const recipientAccount = accounts[8]
-      const authoritiesFiveAccs = [accounts[1], accounts[2], accounts[3], accounts[4], accounts[5]]
-      const validatorContractWith3Signatures = await BridgeValidators.new()
-      await validatorContractWith3Signatures.initialize(3, authoritiesFiveAccs, ownerOfValidators)
-
-      const homeBridgeWithThreeSigs = await HomeBridge.new();
-      await homeBridgeWithThreeSigs.initialize(validatorContractWith3Signatures.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner);
-
-      var newSet = [accounts[1], accounts[2]];
-      const transactionHash = "0x1045bfe274b88120a6b1e5d01b5ec00ab5d01098346e90e7c7a3c9b8f0181c80";
-      var blockNumber = web3.toBigNumber(217455)
-      var message = createNewSetMessage(newSet, transactionHash, blockNumber, homeBridgeWithThreeSigs.address);
-      const signature = await sign(authoritiesFiveAccs[0], message)
-      const signature2 = await sign(authoritiesFiveAccs[1], message)
-      const signature3 = await sign(authoritiesFiveAccs[2], message)
-      '3'.should.be.bignumber.equal(await validatorContractWith3Signatures.requiredSignatures());
-
-      await homeBridgeWithThreeSigs.submitSignatureOfMessageWithUnknownLength(signature, message, {from: authoritiesFiveAccs[0]}).should.be.fulfilled;
-      await homeBridgeWithThreeSigs.submitSignatureOfMessageWithUnknownLength(signature2, message, {from: authoritiesFiveAccs[1]}).should.be.fulfilled;
-      const {logs} = await homeBridgeWithThreeSigs.submitSignatureOfMessageWithUnknownLength(signature3, message, {from: authoritiesFiveAccs[2]}).should.be.fulfilled;
-      logs.length.should.be.equal(2)
-      logs[1].event.should.be.equal('CollectedSignatures')
-      logs[1].args.authorityResponsibleForRelay.should.be.equal(authoritiesFiveAccs[2])
-    })
-    it('attack when increasing requiredSignatures', async () => {
-      var newSet = [accounts[1], accounts[2]];
-      var homeGasPrice = web3.toBigNumber(0);
-      var transactionHash = "0x1045bfe274b88120a6b1e5d01b5ec00ab5d01098346e90e7c7a3c9b8f0181c80";
-      var blockNumber = web3.toBigNumber(217455)
-      var message = createNewSetMessage(newSet, transactionHash, blockNumber, homeBridgeWithTwoSigs.address);
-      var signature = await sign(authoritiesTwoAccs[0], message)
-      var signature2 = await sign(authoritiesTwoAccs[1], message)
-      var signature3 = await sign(authoritiesTwoAccs[2], message)
-      '2'.should.be.bignumber.equal(await validatorContractWith2Signatures.requiredSignatures());
-      await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature, message, {from: authoritiesTwoAccs[0]}).should.be.fulfilled;
-      await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature, message, {from: authoritiesTwoAccs[0]}).should.be.rejectedWith(ERROR_MSG);
-      await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature, message, {from: authoritiesTwoAccs[1]}).should.be.rejectedWith(ERROR_MSG);
-      const {logs} = await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature2, message, {from: authoritiesTwoAccs[1]}).should.be.fulfilled;
-      logs.length.should.be.equal(2)
-      logs[1].event.should.be.equal('CollectedSignatures')
-      logs[1].args.authorityResponsibleForRelay.should.be.equal(authoritiesTwoAccs[1])
-      await validatorContractWith2Signatures.setRequiredSignatures(3).should.be.fulfilled;
-      '3'.should.be.bignumber.equal(await validatorContractWith2Signatures.requiredSignatures());
-      const attackerTx = await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature3, message, {from: authoritiesTwoAccs[2]}).should.be.rejectedWith(ERROR_MSG);
-    })
-    it('attack when decreasing requiredSignatures', async () => {
-      var newSet = [accounts[1], accounts[2]];
-      var homeGasPrice = web3.toBigNumber(0);
-      var transactionHash = "0x1045bfe274b88120a6b1e5d01b5ec00ab5d01098346e90e7c7a3c9b8f0181c80";
-      var blockNumber = web3.toBigNumber(217455)
-      var message = createNewSetMessage(newSet, transactionHash, blockNumber, homeBridgeWithTwoSigs.address);
-      var signature = await sign(authoritiesTwoAccs[0], message)
-      var signature2 = await sign(authoritiesTwoAccs[1], message)
-      var signature3 = await sign(authoritiesTwoAccs[2], message)
-      '2'.should.be.bignumber.equal(await validatorContractWith2Signatures.requiredSignatures());
-      await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature, message, {from: authoritiesTwoAccs[0]}).should.be.fulfilled;
-      await validatorContractWith2Signatures.setRequiredSignatures(1).should.be.fulfilled;
-      '1'.should.be.bignumber.equal(await validatorContractWith2Signatures.requiredSignatures());
-      const {logs} = await homeBridgeWithTwoSigs.submitSignatureOfMessageWithUnknownLength(signature2, message, {from: authoritiesTwoAccs[1]}).should.be.fulfilled;
-      logs.length.should.be.equal(2)
-      logs[1].event.should.be.equal('CollectedSignatures')
-      logs[1].args.authorityResponsibleForRelay.should.be.equal(authoritiesTwoAccs[1])
-    })
-  })
- */
   describe('#requiredMessageLength', async () => {
     beforeEach(async () => {
       homeContract = await HomeBridge.new()

--- a/native-to-erc20/oracle/new_version.sh
+++ b/native-to-erc20/oracle/new_version.sh
@@ -1,4 +1,4 @@
-export TAG=3.0.0
+export TAG=2.0.6
 
 docker build -t fusenet/native-to-erc20-oracle .
 

--- a/native-to-erc20/oracle/new_version.sh
+++ b/native-to-erc20/oracle/new_version.sh
@@ -1,4 +1,4 @@
-export TAG=2.0.6
+export TAG=3.0.0
 
 docker build -t fusenet/native-to-erc20-oracle .
 


### PR DESCRIPTION
- Adding  setValidatorContract method to use a new contract for validation. This method might be removed to the future or transferred to the responsibility of the validator multisig like the rest of admin upgrades.